### PR TITLE
Ensure download of kernel source for the current version

### DIFF
--- a/script
+++ b/script
@@ -13,7 +13,7 @@ rpmdev-setuptree
 if [ -z "$1" ]
 then
   echo "Download kernel source"
-  yumdownloader --source kernel
+  yumdownloader --source kernel-$kernel
 else
   echo "Download kernel source from url: "$1
   wget $1


### PR DESCRIPTION
This change modifies the download command to include the specific kernel version booted by the user.
Previously it downloaded the source of the latest available kernel.